### PR TITLE
Tolerate master:NoSchedule taint

### DIFF
--- a/weave-daemonset.yaml
+++ b/weave-daemonset.yaml
@@ -7,6 +7,16 @@ spec:
     metadata:
       labels:
         name: weave-net
+      annotations:
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [
+            {
+              "key": "dedicated",
+              "operator": "Equal",
+              "value": "master",
+              "effect": "NoSchedule"
+            }
+          ]
     spec:
       hostNetwork: true
       containers:


### PR DESCRIPTION
Ensure we run on all nodes (including master) in spite of the `NoSchedule` taint added by `kubeadm`.

Fixes #1.

cc @errordeveloper PTAL
