### PR TITLE
Router pods inhabit kube-system namespace

### DIFF
--- a/weave-daemonset.yaml
+++ b/weave-daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: weave-net
+  namespace: kube-system
 spec:
   template:
     metadata:


### PR DESCRIPTION
Create the router pods in `kube-system` instead of `default`.
