### PR TITLE
Call expose after re-claiming existing IPs

### DIFF
--- a/image/launch.sh
+++ b/image/launch.sh
@@ -89,9 +89,6 @@ while true ; do
     sleep 1
 done
 
-# Expose the weave network so host processes can communicate with pods
-/home/weave/weave --local expose
-
 reclaim_ips() {
     ID=$1
     shift
@@ -108,5 +105,8 @@ done
 /usr/bin/weaveutil process-addrs weave | while read ID IFACE MAC IPS; do
     reclaim_ips "_" $IPS
 done
+
+# Expose the weave network so host processes can communicate with pods
+/home/weave/weave --local expose
 
 wait $WEAVE_PID


### PR DESCRIPTION
So that we get the same IP as before if IPAM loses its memory

Fixes #25
