### PR TITLE
peer_count should be declared before calling

### DIFF
--- a/image/launch.sh
+++ b/image/launch.sh
@@ -69,13 +69,13 @@ if [ -z "$KUBE_PEERS" ]; then
     fi
 fi
 
-if [ -z "$IPALLOC_INIT" ]; then
-    IPALLOC_INIT="consensus=$(peer_count $KUBE_PEERS)"
-fi
-
 peer_count() {
     echo $#
 }
+
+if [ -z "$IPALLOC_INIT" ]; then
+    IPALLOC_INIT="consensus=$(peer_count $KUBE_PEERS)"
+fi
 
 /home/weave/weaver --port=6783 $BRIDGE_OPTIONS \
      --http-addr=127.0.0.1:6784 --docker-api='' --no-dns \


### PR DESCRIPTION
Hello!
I've trIed to run weave-kube as a static pod and have got an error 

```
/home/weave # KUBE_PEERS=127.0.0.1 ./launch.sh
/home/weave/launch.sh: line 74: peer_count: not found
```

Declaration of function peer_count is placed after call to this function.
